### PR TITLE
Temp fix for #6

### DIFF
--- a/src/util/vehicle.ts
+++ b/src/util/vehicle.ts
@@ -89,7 +89,8 @@ export class Vehicle extends VehicleApi {
         break;
 
       case VolvoSensorBindings.GROUP_HEATER:
-        value = this.state[VolvoSensorBindings.GROUP_HEATER][VolvoSensorBindings.HEATER_STATUS] !== "off" ? true : false;
+        value = this.state[VolvoSensorBindings.GROUP_HEATER] &&
+          this.state[VolvoSensorBindings.GROUP_HEATER][VolvoSensorBindings.HEATER_STATUS] !== "off" ? true : false;
         break;
 
       case VolvoSensorBindings.BATTERY_CHARGE_STATUS:


### PR DESCRIPTION
Prevents errors being thrown when getting heater status while the "heater" object is missing. This is not a permanent fix, as the accessory will always be shown as OFF. However, this allows the user to turn the heater on or off, albeit with incorrect status reporting.