### PR TITLE
Fix enabledFeatures configuration bug

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,6 +17,7 @@ export const getConfig = ({
   updateInterval = DEFAULT_INTERVAL,
   engineStartDuration = DEFAULT_START_DURATION,
   batteryLowThreshold = DEFAULT_BATTERY_THRESHOLD,
+  enabledFeatures,
 }: Partial<Config>): Config => {
   // Ensure no illegal values.
   if (typeof name !== "string") {
@@ -36,7 +37,7 @@ export const getConfig = ({
 
   if (region === "eu") {
     // Angular JSON schema form evaluates empty string to false, thus selecting Europe in the dropdown would not work.
-    // Simple cirumvention. 
+    // Simple cirumvention.
     region = "";
   }
 
@@ -52,6 +53,7 @@ export const getConfig = ({
     updateInterval,
     engineStartDuration,
     batteryLowThreshold,
+    enabledFeatures,
   };
 };
 

--- a/src/util/vehicle.ts
+++ b/src/util/vehicle.ts
@@ -59,7 +59,7 @@ export class Vehicle extends VehicleApi {
 
     if (this.config.enabledFeatures) {
       for (const feature in this.config.enabledFeatures) {
-        if (Object.prototype.hasOwnProperty.call(this.config, feature) && !this.config.enabledFeatures[feature]) {
+        if (Object.prototype.hasOwnProperty.call(this.config.enabledFeatures, feature) && !this.config.enabledFeatures[feature]) {
           // User has disabled the feature, so we disable it as well.
           this.features[feature] = false;
         }


### PR DESCRIPTION
There were a few problems causing the enabledFeatures configuation object
from being ignored (thus all features were enabled, even when the user
preferred to hide some):

1. the object was not being included in the object returned from
   src/helpers.ts, and

2. the check to see which features were disabled was trying to find the
   feature name in the `config` object directly, instead of looking in
   `config.enabledFeatures`.

This change allows users to hide features they would prefer not to see
(or that are currently malfunctioning, i.e., preclimatization), and thus
resolves Issue #12.