### PR TITLE
Disable preclimatization, by default

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -94,7 +94,7 @@
         },
         "preclimatizationSupported": {
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "engineStartSupported": {
           "type": "boolean",


### PR DESCRIPTION
Pre-climatization seems to be causing many people problems,
probably because the `heater` object is no longer returned in the
response from the API.

While we work on fixing that (if possible), it makes sense to disable
the preclimatization features, by default .. because no HomeKit user
likes to see "No response" on their Home screen.